### PR TITLE
Add configurable CLI command for spawning sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,7 @@ export const DEFAULTS = {
   SESSIONS_FILE: '~/.vibecraft/data/sessions.json',
   MAX_EVENTS: 1000,
   TMUX_SESSION: 'claude',
+  CLAUDE_COMMAND: 'claude',       // CLI command (or 'happy', etc.)
 }
 ```
 
@@ -456,6 +457,7 @@ This file is imported by:
 Vibecraft stores all data in `~/.vibecraft/data/`:
 - `events.jsonl` - Event log (append-only)
 - `sessions.json` - Session persistence
+- `config.json` - Server config (CLI command, etc.)
 - `tiles.json` - Text tile labels
 - `pending-prompt.txt` - Queued prompt (optional)
 
@@ -489,6 +491,7 @@ Environment variables override the defaults:
 | `VIBECRAFT_TMUX_SESSION` | claude | tmux session for prompt injection |
 | `VIBECRAFT_SESSIONS_FILE` | ~/.vibecraft/data/sessions.json | Session persistence file |
 | `VIBECRAFT_DATA_DIR` | ~/.vibecraft/data | Hook data directory |
+| `VIBECRAFT_CLAUDE_COMMAND` | claude | CLI command to spawn sessions (e.g., "happy") |
 | `DEEPGRAM_API_KEY` | (none) | Deepgram API key for voice input |
 
 A `.env` file is included with defaults - just run `npm run dev`.

--- a/index.html
+++ b/index.html
@@ -260,6 +260,14 @@
         </div>
 
         <div class="modal-field">
+          <label>CLI Command</label>
+          <div class="settings-command-row">
+            <input type="text" id="settings-cli-command" value="claude" placeholder="claude" />
+          </div>
+          <div class="field-hint">Command to spawn new sessions (e.g., "claude" or "happy"). Takes effect immediately.</div>
+        </div>
+
+        <div class="modal-field">
           <label>Sessions</label>
           <div class="settings-actions">
             <button type="button" class="settings-action-btn" id="settings-refresh-sessions">🔄 Refresh Sessions</button>

--- a/server/index.ts
+++ b/server/index.ts
@@ -86,6 +86,8 @@ const MAX_EVENTS = parseInt(process.env.VIBECRAFT_MAX_EVENTS ?? String(DEFAULTS.
 const DEBUG = process.env.VIBECRAFT_DEBUG === 'true'
 const TMUX_SESSION = process.env.VIBECRAFT_TMUX_SESSION ?? DEFAULTS.TMUX_SESSION
 const SESSIONS_FILE = resolve(expandHome(process.env.VIBECRAFT_SESSIONS_FILE ?? DEFAULTS.SESSIONS_FILE))
+const CONFIG_FILE = resolve(expandHome(process.env.VIBECRAFT_CONFIG_FILE ?? '~/.vibecraft/data/config.json'))
+let claudeCommand = process.env.VIBECRAFT_CLAUDE_COMMAND ?? DEFAULTS.CLAUDE_COMMAND
 const TILES_FILE = resolve(expandHome(process.env.VIBECRAFT_TILES_FILE ?? '~/.vibecraft/data/tiles.json'))
 
 /** Time before a "working" session auto-transitions to idle (failsafe for missed events) */
@@ -795,7 +797,7 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       claudeArgs.push('--chrome')
     }
 
-    const claudeCmd = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude'
+    const claudeCmd = claudeArgs.length > 0 ? `${claudeCommand} ${claudeArgs.join(' ')}` : claudeCommand
 
     // Spawn tmux session with claude using execFile to prevent shell injection
     // Arguments are passed as array, not interpolated into a shell string
@@ -1061,6 +1063,42 @@ function loadSessions(): void {
     log(`Loaded ${managedSessions.size} sessions from ${SESSIONS_FILE}`)
   } catch (e) {
     console.error('Failed to load sessions:', e)
+  }
+}
+
+/**
+ * Save config to disk for persistence across restarts
+ */
+function saveConfig(): void {
+  try {
+    const data = { cliCommand: claudeCommand }
+    writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2))
+    debug(`Saved config to ${CONFIG_FILE}`)
+  } catch (e) {
+    console.error('Failed to save config:', e)
+  }
+}
+
+/**
+ * Load config from disk on startup
+ */
+function loadConfig(): void {
+  if (!existsSync(CONFIG_FILE)) {
+    debug('No saved config file found')
+    return
+  }
+
+  try {
+    const content = readFileSync(CONFIG_FILE, 'utf-8')
+    const data = JSON.parse(content)
+
+    // Only apply saved config if no env var override
+    if (!process.env.VIBECRAFT_CLAUDE_COMMAND && typeof data.cliCommand === 'string') {
+      claudeCommand = data.cliCommand
+      log(`Loaded CLI command from config: ${claudeCommand}`)
+    }
+  } catch (e) {
+    console.error('Failed to load config:', e)
   }
 }
 
@@ -1715,6 +1753,36 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     return
   }
 
+  // Get server config
+  if (req.method === 'GET' && req.url === '/config') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ok: true, cliCommand: claudeCommand }))
+    return
+  }
+
+  // Update server config
+  if (req.method === 'PATCH' && req.url === '/config') {
+    collectRequestBody(req).then(body => {
+      try {
+        const data = body ? JSON.parse(body) : {}
+        if (typeof data.cliCommand === 'string' && data.cliCommand.trim()) {
+          claudeCommand = data.cliCommand.trim()
+          log(`CLI command updated to: ${claudeCommand}`)
+          saveConfig()
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, cliCommand: claudeCommand }))
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Invalid JSON' }))
+      }
+    }).catch(() => {
+      res.writeHead(413, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: false, error: 'Request body too large' }))
+    })
+    return
+  }
+
   // List all sessions
   if (req.method === 'GET' && req.url === '/sessions') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
@@ -1958,7 +2026,7 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           '-d',
           '-s', session.tmuxSession,
           '-c', cwd,
-          `PATH=${EXEC_PATH} claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions`
+          `PATH=${EXEC_PATH} ${claudeCommand} -c --permission-mode=bypassPermissions --dangerously-skip-permissions`
         ], EXEC_OPTIONS, (error) => {
           if (error) {
             res.writeHead(500, { 'Content-Type': 'application/json' })
@@ -2219,6 +2287,9 @@ function main() {
 
   // Load saved sessions (for persistence across restarts)
   loadSessions()
+
+  // Load saved config (CLI command, etc.)
+  loadConfig()
 
   // Load saved text tiles
   loadTiles()

--- a/shared/defaults.ts
+++ b/shared/defaults.ts
@@ -31,6 +31,9 @@ export const DEFAULTS = {
 
   /** tmux session name */
   TMUX_SESSION: 'claude',
+
+  /** CLI command to run (e.g., 'claude' or 'happy') */
+  CLAUDE_COMMAND: 'claude',
 } as const
 
 export type Defaults = typeof DEFAULTS

--- a/src/main.ts
+++ b/src/main.ts
@@ -2440,9 +2440,9 @@ function setupSettingsModal(): void {
     }
   })
 
-  // CLI command change - save to server
-  cliCommandInput?.addEventListener('change', () => {
-    const newCommand = cliCommandInput.value.trim()
+  // CLI command - save to server
+  const saveCliCommand = () => {
+    const newCommand = cliCommandInput?.value.trim()
     if (newCommand) {
       fetch(`${API_URL}/config`, {
         method: 'PATCH',
@@ -2452,12 +2452,22 @@ function setupSettingsModal(): void {
         .then(res => res.json())
         .then(data => {
           if (data.ok) {
-            console.log(`CLI command updated to: ${data.cliCommand}`)
+            toast.success(`CLI command set to "${data.cliCommand}"`, { duration: 2000 })
           }
         })
         .catch(err => {
           console.error('Failed to update CLI command:', err)
+          toast.error('Failed to save CLI command', { duration: 3000 })
         })
+    }
+  }
+
+  cliCommandInput?.addEventListener('change', saveCliCommand)
+  cliCommandInput?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      saveCliCommand()
+      cliCommandInput.blur()
     }
   })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2288,6 +2288,9 @@ function setupSettingsModal(): void {
   const portInput = document.getElementById('settings-port') as HTMLInputElement | null
   const portStatus = document.getElementById('settings-port-status')
 
+  // CLI command input
+  const cliCommandInput = document.getElementById('settings-cli-command') as HTMLInputElement | null
+
   // Load saved volume from localStorage
   const savedVolume = localStorage.getItem('vibecraft-volume')
   if (savedVolume !== null) {
@@ -2365,6 +2368,19 @@ function setupSettingsModal(): void {
       portStatus.textContent = connected ? '● Connected' : '○ Disconnected'
       portStatus.className = `port-status ${connected ? 'connected' : 'disconnected'}`
     }
+    // Fetch current CLI command from server
+    if (cliCommandInput) {
+      fetch(`${API_URL}/config`)
+        .then(res => res.json())
+        .then(data => {
+          if (data.ok && data.cliCommand) {
+            cliCommandInput.value = data.cliCommand
+          }
+        })
+        .catch(() => {
+          // Keep default value on error
+        })
+    }
     modal.classList.add('visible')
   })
 
@@ -2421,6 +2437,27 @@ function setupSettingsModal(): void {
       if (confirm(`Port changed to ${newPort}. Reload page to connect to new port?`)) {
         window.location.reload()
       }
+    }
+  })
+
+  // CLI command change - save to server
+  cliCommandInput?.addEventListener('change', () => {
+    const newCommand = cliCommandInput.value.trim()
+    if (newCommand) {
+      fetch(`${API_URL}/config`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cliCommand: newCommand }),
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (data.ok) {
+            console.log(`CLI command updated to: ${data.cliCommand}`)
+          }
+        })
+        .catch(err => {
+          console.error('Failed to update CLI command:', err)
+        })
     }
   })
 

--- a/src/styles/modals.css
+++ b/src/styles/modals.css
@@ -351,6 +351,28 @@
   color: #f87171;
 }
 
+/* CLI Command input */
+.settings-command-row {
+  display: flex;
+  align-items: center;
+}
+
+#settings-cli-command {
+  width: 160px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: #fff;
+  font-family: monospace;
+  font-size: 14px;
+  outline: none;
+}
+
+#settings-cli-command:focus {
+  border-color: #a78bfa;
+}
+
 /* Settings sliders (volume, grid size, etc.) */
 .settings-slider-row {
   display: flex;


### PR DESCRIPTION
## Goal
I wanted to use [happy](https://github.com/slopus/happy) to code from my phone, but the command uses claude. This PR allows to change the CLI command.

## Summary
- Allows users to specify a custom CLI command (e.g., "happy" instead of "claude") for spawning new sessions
- Setting is accessible in the settings modal and persists to `~/.vibecraft/data/config.json`
- Supports `VIBECRAFT_CLAUDE_COMMAND` env var override

## Test plan
- [x] Open settings modal and change CLI Command field
- [x] Verify new sessions spawn using the configured command
- [x] Restart server and verify setting persists

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)