### PR TITLE
Add + New button to session list sidebar

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -313,6 +313,19 @@ function renderManagedSessions(): void {
 
     container.appendChild(el)
   })
+
+  // Add "+ New" button at the end of the grid
+  const newBtn = document.createElement('div')
+  newBtn.className = 'session-item new-session-card'
+  newBtn.innerHTML = `
+    <div class="session-icon">➕</div>
+    <div class="session-info">
+      <div class="session-name">New Session</div>
+      <div class="session-detail">Alt+N</div>
+    </div>
+  `
+  newBtn.addEventListener('click', () => openNewSessionModal())
+  container.appendChild(newBtn)
 }
 
 /**

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -273,3 +273,23 @@
   border-color: rgba(167, 139, 250, 0.4);
   color: #c4b5fd;
 }
+
+/* New Session card button */
+.session-item.new-session-card {
+  background: rgba(74, 222, 128, 0.08);
+  border: 1px dashed rgba(74, 222, 128, 0.3);
+  justify-content: center;
+}
+
+.session-item.new-session-card:hover {
+  background: rgba(74, 222, 128, 0.15);
+  border-color: rgba(74, 222, 128, 0.5);
+}
+
+.session-item.new-session-card .session-icon {
+  color: #4ade80;
+}
+
+.session-item.new-session-card .session-name {
+  color: #4ade80;
+}


### PR DESCRIPTION
## Summary
- Adds a styled "+ New Session" card button at the bottom of the sessions grid
- Makes it easy to create new sessions without clicking on the map
- Shows Alt+N keyboard shortcut hint for power users

## Test plan
- [ ] Open the sidebar and verify the "+ New" card appears at the end of the session list
- [ ] Click the card and verify the new session modal opens
- [ ] Verify hover state styling matches the green theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)