### PR TITLE
Skip ephemeral UI during history replay and merge result sounds into Tools

### DIFF
--- a/src/audio/SoundManager.ts
+++ b/src/audio/SoundManager.ts
@@ -155,10 +155,75 @@ interface SynthConfig {
   release: number
 }
 
+// Sound categories for UI organization
+export const SOUND_CATEGORIES: Record<string, { label: string; sounds: SoundName[] }> = {
+  tools: {
+    label: 'Tools',
+    sounds: ['read', 'write', 'edit', 'bash', 'grep', 'webfetch', 'task', 'todo', 'success', 'error'],
+  },
+  events: {
+    label: 'Session Events',
+    sounds: ['prompt', 'stop', 'thinking', 'spawn', 'despawn', 'notification'],
+  },
+  zones: {
+    label: 'Zones',
+    sounds: ['zone_create', 'zone_delete', 'focus'],
+  },
+  ui: {
+    label: 'UI',
+    sounds: ['click', 'modal_open', 'modal_confirm', 'modal_cancel', 'walking', 'hover'],
+  },
+  voice: {
+    label: 'Voice',
+    sounds: ['voice_start', 'voice_stop'],
+  },
+  special: {
+    label: 'Special',
+    sounds: ['git_commit', 'intro', 'clear'],
+  },
+}
+
+// Human-readable labels for sounds
+export const SOUND_LABELS: Record<SoundName, string> = {
+  read: 'Read File',
+  write: 'Write File',
+  edit: 'Edit File',
+  bash: 'Bash Command',
+  grep: 'Search (Grep)',
+  glob: 'Search (Glob)',
+  webfetch: 'Web Fetch',
+  websearch: 'Web Search',
+  task: 'Task/Agent',
+  todo: 'Todo Update',
+  git_commit: 'Git Commit',
+  clear: 'Clear',
+  success: 'Success',
+  error: 'Error',
+  walking: 'Walking',
+  focus: 'Zone Focus',
+  click: 'Click',
+  modal_open: 'Modal Open',
+  modal_cancel: 'Modal Cancel',
+  modal_confirm: 'Modal Confirm',
+  hover: 'Hover',
+  spawn: 'Agent Spawn',
+  despawn: 'Agent Despawn',
+  zone_create: 'Zone Create',
+  zone_delete: 'Zone Delete',
+  prompt: 'Prompt Submit',
+  stop: 'Session Stop',
+  notification: 'Notification',
+  thinking: 'Thinking',
+  voice_start: 'Voice Start',
+  voice_stop: 'Voice Stop',
+  intro: 'Startup',
+}
+
 class SoundManager {
   private initialized = false
   private enabled = true
   private volume = 0.7 // 0-1 (maps to master gain)
+  private mutedSounds: Set<SoundName> = new Set()
 
   // Synth pools by oscillator type (reduces GC)
   private synthPools: Map<OscType, Tone.Synth[]> = new Map([
@@ -232,6 +297,56 @@ class SoundManager {
   }
 
   // ============================================
+  // Per-Sound Muting
+  // ============================================
+
+  /**
+   * Mute a specific sound
+   */
+  muteSound(name: SoundName): void {
+    this.mutedSounds.add(name)
+  }
+
+  /**
+   * Unmute a specific sound
+   */
+  unmuteSound(name: SoundName): void {
+    this.mutedSounds.delete(name)
+  }
+
+  /**
+   * Set whether a specific sound is muted
+   */
+  setSoundMuted(name: SoundName, muted: boolean): void {
+    if (muted) {
+      this.mutedSounds.add(name)
+    } else {
+      this.mutedSounds.delete(name)
+    }
+  }
+
+  /**
+   * Check if a specific sound is muted
+   */
+  isSoundMuted(name: SoundName): boolean {
+    return this.mutedSounds.has(name)
+  }
+
+  /**
+   * Get all muted sounds
+   */
+  getMutedSounds(): SoundName[] {
+    return Array.from(this.mutedSounds)
+  }
+
+  /**
+   * Set all muted sounds at once (replaces current muted set)
+   */
+  setMutedSounds(sounds: SoundName[]): void {
+    this.mutedSounds = new Set(sounds)
+  }
+
+  // ============================================
   // Spatial Audio Configuration
   // ============================================
 
@@ -281,6 +396,9 @@ class SoundManager {
    */
   play(name: SoundName, options?: SoundPlayOptions): void {
     if (!this.initialized || !this.enabled) return
+
+    // Check if this specific sound is muted
+    if (this.mutedSounds.has(name)) return
 
     const soundFn = this.sounds[name]
     if (!soundFn) {

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -1,4 +1,4 @@
-export { soundManager, SoundManager } from './SoundManager'
+export { soundManager, SoundManager, SOUND_CATEGORIES, SOUND_LABELS } from './SoundManager'
 export type { SoundName, SoundPlayOptions } from './SoundManager'
 export { spatialAudioContext, SpatialAudioContext } from './SpatialAudioContext'
 export type { SpatialMode, SpatialSource, SpatialParams } from './SpatialAudioContext'

--- a/src/events/EventBus.ts
+++ b/src/events/EventBus.ts
@@ -43,6 +43,8 @@ export interface EventContext {
   session: SessionContext | null
   /** Sound enabled flag */
   soundEnabled: boolean
+  /** Whether this event is from history replay (vs real-time) */
+  isHistory: boolean
 }
 
 /**

--- a/src/events/handlers/notificationHandlers.ts
+++ b/src/events/handlers/notificationHandlers.ts
@@ -3,6 +3,7 @@
  *
  * Shows floating notifications above zones when tools complete.
  * Uses ZoneNotifications system for tool-specific styling.
+ * Also handles Claude Code notification events (permission prompts, etc).
  */
 
 import { eventBus } from '../EventBus'
@@ -11,8 +12,27 @@ import {
   formatCommandResult,
   formatSearchResult,
 } from '../../scene/ZoneNotifications'
-import type { PostToolUseEvent } from '../../../shared/types'
+import { showToast, type ToastType } from '../../ui/Toast'
+import type { PostToolUseEvent, NotificationEvent } from '../../../shared/types'
 import { getStationForTool } from '../../../shared/types'
+
+/**
+ * Map notification types to toast styling
+ */
+function getNotificationStyle(notificationType: string): { type: ToastType; icon: string } {
+  switch (notificationType) {
+    case 'permission_prompt':
+      return { type: 'warning', icon: '🔐' }
+    case 'idle_prompt':
+      return { type: 'info', icon: '💤' }
+    case 'auth_success':
+      return { type: 'success', icon: '✅' }
+    case 'elicitation_dialog':
+      return { type: 'info', icon: '💬' }
+    default:
+      return { type: 'info', icon: '🔔' }
+  }
+}
 
 /**
  * Register notification-related event handlers
@@ -22,7 +42,8 @@ export function registerNotificationHandlers(): void {
   eventBus.on('post_tool_use', (event: PostToolUseEvent, ctx) => {
     // Skip ephemeral notifications during history replay - zones may not exist yet
     // and old notifications don't make sense (they're 3-second transient feedback)
-    if (!event.success || !ctx.scene || ctx.isHistory) return
+    // Also need a linked session to show zone notifications
+    if (!event.success || !ctx.scene || ctx.isHistory || !ctx.session) return
 
     const input = event.toolInput as Record<string, unknown>
     let notificationText: string | null = null
@@ -127,6 +148,33 @@ export function registerNotificationHandlers(): void {
           success: event.success,
         })
       }
+    }
+  })
+
+  // Claude Code notification events (permission prompts, idle prompts, etc.)
+  eventBus.on('notification', (event, ctx) => {
+    // Skip during history replay
+    if (ctx.isHistory) return
+
+    const notifEvent = event as unknown as NotificationEvent
+    const { message, notificationType } = notifEvent
+    const style = getNotificationStyle(notificationType)
+
+    // Show toast notification for global visibility
+    showToast(message, {
+      type: style.type,
+      icon: style.icon,
+      duration: 5000, // Longer duration for system notifications
+    })
+
+    // Also show zone notification if we have a linked session
+    if (ctx.scene && ctx.session) {
+      ctx.scene.zoneNotifications.show(ctx.session.id, {
+        text: message.slice(0, 40),
+        icon: style.icon,
+        style: style.type === 'warning' ? 'warning' : style.type === 'error' ? 'error' : 'info',
+        duration: 4,
+      })
     }
   })
 }

--- a/src/events/handlers/notificationHandlers.ts
+++ b/src/events/handlers/notificationHandlers.ts
@@ -20,7 +20,9 @@ import { getStationForTool } from '../../../shared/types'
 export function registerNotificationHandlers(): void {
   // Tool completion notifications
   eventBus.on('post_tool_use', (event: PostToolUseEvent, ctx) => {
-    if (!event.success || !ctx.scene) return
+    // Skip ephemeral notifications during history replay - zones may not exist yet
+    // and old notifications don't make sense (they're 3-second transient feedback)
+    if (!event.success || !ctx.scene || ctx.isHistory) return
 
     const input = event.toolInput as Record<string, unknown>
     let notificationText: string | null = null

--- a/src/events/handlers/soundHandlers.ts
+++ b/src/events/handlers/soundHandlers.ts
@@ -35,7 +35,7 @@ function getSpatialOptions(ctx: { session: { id: string } | null }): SoundPlayOp
 export function registerSoundHandlers(): void {
   // Tool start sounds (with special handling for git commit)
   eventBus.on('pre_tool_use', (event: PreToolUseEvent, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     const spatial = getSpatialOptions(ctx)
 
     // Special sound for git commit (global, no spatial)
@@ -52,7 +52,7 @@ export function registerSoundHandlers(): void {
 
   // Subagent spawn sound (Task tool start)
   eventBus.on('pre_tool_use', (event: PreToolUseEvent, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     if (event.tool === 'Task') {
       const spatial = getSpatialOptions(ctx)
       soundManager.play('spawn', spatial)
@@ -61,14 +61,14 @@ export function registerSoundHandlers(): void {
 
   // Tool completion sounds (success/error)
   eventBus.on('post_tool_use', (event: PostToolUseEvent, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     const spatial = getSpatialOptions(ctx)
     soundManager.playResult(event.success, spatial)
   })
 
   // Subagent despawn sound
   eventBus.on('post_tool_use', (event: PostToolUseEvent, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     if (event.tool === 'Task') {
       const spatial = getSpatialOptions(ctx)
       soundManager.play('despawn', spatial)
@@ -77,21 +77,21 @@ export function registerSoundHandlers(): void {
 
   // Stop/completion sound
   eventBus.on('stop', (_event, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     const spatial = getSpatialOptions(ctx)
     soundManager.play('stop', spatial)
   })
 
   // Prompt received sound
   eventBus.on('user_prompt_submit', (_event, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     const spatial = getSpatialOptions(ctx)
     soundManager.play('prompt', spatial)
   })
 
   // Notification sound (global, no spatial)
   eventBus.on('notification', (_event, ctx) => {
-    if (!ctx.soundEnabled) return
+    if (!ctx.soundEnabled || ctx.isHistory) return
     soundManager.play('notification')  // Global sound, no spatial
   })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,8 @@ import {
   type PostToolUseEvent,
   type ManagedSession,
 } from '../shared/types'
-import { soundManager } from './audio'
+import { soundManager, SOUND_CATEGORIES, SOUND_LABELS } from './audio'
+import type { SoundName } from './audio'
 
 // Expose for console testing (can remove in production)
 ;(window as any).soundManager = soundManager
@@ -1745,7 +1746,7 @@ function updateStats() {
 // Event Handling
 // ============================================================================
 
-function handleEvent(event: ClaudeEvent) {
+function handleEvent(event: ClaudeEvent, isHistory = false) {
   // Get or create session for this event
   // Returns null if the session isn't linked to a managed session
   const session = getOrCreateSession(event.sessionId)
@@ -1759,6 +1760,7 @@ function handleEvent(event: ClaudeEvent) {
     feedManager: state.feedManager,
     timelineManager: state.timelineManager,
     soundEnabled: state.soundEnabled,
+    isHistory,
     session: session ? {
       id: event.sessionId,
       color: session.color,
@@ -1871,7 +1873,10 @@ function handleEvent(event: ClaudeEvent) {
 
       // Show thinking indicator AFTER feedManager.add() to ensure correct order
       // (prompt appears first, then thinking indicator)
-      state.feedManager?.showThinking(event.sessionId, session.color)
+      // Skip during history replay - ephemeral UI that doesn't need to be restored
+      if (!isHistory) {
+        state.feedManager?.showThinking(event.sessionId, session.color)
+      }
 
       // Update UI badge (zone attention cleared by zoneHandlers)
       updateAttentionBadge()
@@ -2322,6 +2327,118 @@ function setupSettingsModal(): void {
     applyStreamingMode(enabled)
   }
 
+  // ============================================
+  // Sound Preferences Setup
+  // ============================================
+  const soundPrefsToggle = document.getElementById('sound-prefs-toggle')
+  const soundPrefsContainer = document.getElementById('sound-prefs-container')
+
+  // Load saved muted sounds from localStorage
+  const savedMutedSounds = localStorage.getItem('vibecraft-muted-sounds')
+  if (savedMutedSounds !== null) {
+    try {
+      const mutedSounds = JSON.parse(savedMutedSounds) as SoundName[]
+      soundManager.setMutedSounds(mutedSounds)
+    } catch {
+      // Invalid JSON, ignore
+    }
+  }
+
+  // Populate sound preferences UI
+  if (soundPrefsContainer) {
+    // Helper to update category checkbox state based on individual sounds
+    const updateCategoryCheckbox = (categoryCheckbox: HTMLInputElement, sounds: SoundName[]) => {
+      const mutedCount = sounds.filter(s => soundManager.isSoundMuted(s)).length
+      if (mutedCount === 0) {
+        categoryCheckbox.checked = true
+        categoryCheckbox.indeterminate = false
+      } else if (mutedCount === sounds.length) {
+        categoryCheckbox.checked = false
+        categoryCheckbox.indeterminate = false
+      } else {
+        categoryCheckbox.checked = false
+        categoryCheckbox.indeterminate = true
+      }
+    }
+
+    // Helper to save muted sounds to localStorage
+    const saveMutedSounds = () => {
+      const mutedSounds = soundManager.getMutedSounds()
+      localStorage.setItem('vibecraft-muted-sounds', JSON.stringify(mutedSounds))
+    }
+
+    for (const [categoryKey, category] of Object.entries(SOUND_CATEGORIES)) {
+      const categoryDiv = document.createElement('div')
+      categoryDiv.className = 'sound-prefs-category'
+
+      // Category header with toggle-all checkbox
+      const header = document.createElement('div')
+      header.className = 'sound-prefs-category-header'
+
+      const categoryCheckbox = document.createElement('input')
+      categoryCheckbox.type = 'checkbox'
+      categoryCheckbox.id = `sound-category-${categoryKey}`
+      updateCategoryCheckbox(categoryCheckbox, category.sounds)
+
+      const categoryLabel = document.createElement('label')
+      categoryLabel.className = 'sound-prefs-category-label'
+      categoryLabel.htmlFor = `sound-category-${categoryKey}`
+      categoryLabel.textContent = category.label
+
+      header.appendChild(categoryCheckbox)
+      header.appendChild(categoryLabel)
+      categoryDiv.appendChild(header)
+
+      // Category checkbox toggles all sounds in category
+      categoryCheckbox.addEventListener('change', () => {
+        const shouldMute = !categoryCheckbox.checked
+        for (const soundName of category.sounds) {
+          soundManager.setSoundMuted(soundName, shouldMute)
+          const soundCheckbox = document.getElementById(`sound-pref-${soundName}`) as HTMLInputElement | null
+          if (soundCheckbox) soundCheckbox.checked = !shouldMute
+        }
+        categoryCheckbox.indeterminate = false
+        saveMutedSounds()
+      })
+
+      const grid = document.createElement('div')
+      grid.className = 'sound-prefs-grid'
+
+      for (const soundName of category.sounds) {
+        const item = document.createElement('div')
+        item.className = 'sound-pref-item'
+
+        const checkbox = document.createElement('input')
+        checkbox.type = 'checkbox'
+        checkbox.id = `sound-pref-${soundName}`
+        checkbox.checked = !soundManager.isSoundMuted(soundName)
+
+        checkbox.addEventListener('change', () => {
+          soundManager.setSoundMuted(soundName, !checkbox.checked)
+          updateCategoryCheckbox(categoryCheckbox, category.sounds)
+          saveMutedSounds()
+        })
+
+        const label = document.createElement('label')
+        label.htmlFor = `sound-pref-${soundName}`
+        label.textContent = SOUND_LABELS[soundName] || soundName
+
+        item.appendChild(checkbox)
+        item.appendChild(label)
+        grid.appendChild(item)
+      }
+
+      categoryDiv.appendChild(grid)
+      soundPrefsContainer.appendChild(categoryDiv)
+    }
+  }
+
+  // Toggle sound preferences visibility
+  soundPrefsToggle?.addEventListener('click', () => {
+    const isExpanded = soundPrefsToggle.classList.toggle('expanded')
+    soundPrefsContainer?.classList.toggle('visible', isExpanded)
+  })
+
   // Apply streaming mode (hide/show username)
   function applyStreamingMode(enabled: boolean) {
     const usernameEl = document.getElementById('username')
@@ -2356,6 +2473,32 @@ function setupSettingsModal(): void {
     // Sync streaming mode checkbox
     if (streamingCheckbox) {
       streamingCheckbox.checked = localStorage.getItem('vibecraft-streaming-mode') === 'true'
+    }
+    // Sync sound preferences checkboxes (individual and category)
+    for (const [categoryKey, category] of Object.entries(SOUND_CATEGORIES)) {
+      let mutedCount = 0
+      for (const soundName of category.sounds) {
+        const checkbox = document.getElementById(`sound-pref-${soundName}`) as HTMLInputElement | null
+        if (checkbox) {
+          const isMuted = soundManager.isSoundMuted(soundName)
+          checkbox.checked = !isMuted
+          if (isMuted) mutedCount++
+        }
+      }
+      // Update category checkbox
+      const categoryCheckbox = document.getElementById(`sound-category-${categoryKey}`) as HTMLInputElement | null
+      if (categoryCheckbox) {
+        if (mutedCount === 0) {
+          categoryCheckbox.checked = true
+          categoryCheckbox.indeterminate = false
+        } else if (mutedCount === category.sounds.length) {
+          categoryCheckbox.checked = false
+          categoryCheckbox.indeterminate = false
+        } else {
+          categoryCheckbox.checked = false
+          categoryCheckbox.indeterminate = true
+        }
+      }
     }
     // Sync port input
     if (portInput) portInput.value = String(AGENT_PORT)
@@ -2667,8 +2810,9 @@ function init() {
       }
     }
     // Second pass: process all events (sessions created dynamically)
+    // Mark as history so ephemeral UI (notifications) is skipped
     for (const event of events) {
-      handleEvent(event)
+      handleEvent(event, true)
     }
   })
 


### PR DESCRIPTION
## Summary
- Add `isHistory` flag to `EventContext` to distinguish history replay from real-time events
- Skip floating notifications during history (zones may not exist yet, old notifications don't make sense)
- Skip all sounds during history replay (prevents cascade of sounds on page refresh)
- Skip thinking indicator during history replay
- Merge success/error sounds into Tools category (disabling tool sounds now also disables result sounds)

## Test plan
- [ ] Refresh page with tool sounds disabled - should not hear any tool or result sounds
- [ ] Disable Tools in Sound Preferences - success/error sounds should also be muted
- [ ] Real-time events should still trigger sounds and notifications normally

🤖 Generated with [Claude Code](https://claude.ai/code)