### PR TITLE
Add OpenAI Codex CLI support

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,8 +180,24 @@
           <input type="text" id="session-name-input" placeholder="Auto-filled from directory..." autocomplete="off" />
         </div>
 
+        <!-- Agent Selector -->
         <div class="modal-field">
-          <label>Options</label>
+          <label>Agent</label>
+          <div class="modal-agent-selector">
+            <label class="modal-agent-option">
+              <input type="radio" name="session-agent" value="claude" checked />
+              <span class="agent-label">🧠 Claude</span>
+            </label>
+            <label class="modal-agent-option">
+              <input type="radio" name="session-agent" value="codex" />
+              <span class="agent-label">🤖 Codex</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Claude Options -->
+        <div class="modal-field" id="claude-options">
+          <label>Claude Options</label>
           <div class="modal-checkboxes">
             <label class="modal-checkbox">
               <input type="checkbox" id="session-opt-continue" />
@@ -195,6 +211,28 @@
               <input type="checkbox" id="session-opt-chrome" />
               <span class="checkbox-label">Chrome <code>--chrome</code></span>
             </label>
+          </div>
+        </div>
+
+        <!-- Codex Options (hidden by default) -->
+        <div class="modal-field" id="codex-options" style="display: none;">
+          <label>Codex Options</label>
+          <div class="modal-checkboxes">
+            <label class="modal-checkbox">
+              <input type="checkbox" id="session-opt-codex-skip-perms" checked />
+              <span class="checkbox-label">Skip permissions <code>--dangerously-bypass-approvals-and-sandbox</code></span>
+            </label>
+          </div>
+          <div class="modal-field" style="margin-top: 10px;">
+            <label for="session-codex-model">Model</label>
+            <select id="session-codex-model">
+              <option value="">Default (from config)</option>
+              <option value="gpt-5.2-codex" selected>GPT-5.2 Codex</option>
+              <option value="o3">o3</option>
+              <option value="o3-mini">o3-mini</option>
+              <option value="o1">o1</option>
+              <option value="gpt-4.1">GPT-4.1</option>
+            </select>
           </div>
         </div>
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -450,7 +450,8 @@ function startTokenPolling(): void {
   // Poll every 2 seconds - poll all managed sessions
   setInterval(() => {
     for (const session of managedSessions.values()) {
-      if (session.status !== 'offline') {
+      // Only poll internal sessions (they have tmuxSession)
+      if (session.status !== 'offline' && session.tmuxSession) {
         pollTokens(session.tmuxSession)
       }
     }
@@ -695,7 +696,8 @@ function startPermissionPolling(): void {
   // Poll every 1 second (more frequent than tokens since permissions are time-sensitive)
   setInterval(() => {
     for (const session of managedSessions.values()) {
-      if (session.status !== 'offline') {
+      // Only poll internal sessions (they have tmuxSession)
+      if (session.status !== 'offline' && session.tmuxSession) {
         pollPermissions(session.id, session.tmuxSession)
       }
     }
@@ -720,6 +722,12 @@ function sendPermissionResponse(sessionId: string, optionNumber: string): boolea
     return false
   }
 
+  // Only internal sessions have tmuxSession
+  if (!session.tmuxSession) {
+    log(`Cannot send permission response: session ${sessionId} is external (no tmux)`)
+    return false
+  }
+
   // Validate tmux session name
   try {
     validateTmuxSession(session.tmuxSession)
@@ -728,8 +736,11 @@ function sendPermissionResponse(sessionId: string, optionNumber: string): boolea
     return false
   }
 
+  // TypeScript now knows tmuxSession is string (not undefined)
+  const tmuxSession = session.tmuxSession
+
   // Send the option number to tmux - Claude Code expects just the number
-  execFile('tmux', ['send-keys', '-t', session.tmuxSession, optionNumber], EXEC_OPTIONS, (error) => {
+  execFile('tmux', ['send-keys', '-t', tmuxSession, optionNumber], EXEC_OPTIONS, (error: Error | null) => {
     if (error) {
       log(`Failed to send permission response: ${error.message}`)
       return
@@ -828,48 +839,64 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       agentCmd = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude'
     }
 
-    // Spawn tmux session with agent using execFile to prevent shell injection
-    // Arguments are passed as array, not interpolated into a shell string
+    // Two-step approach: create session without command, then send agent command via send-keys
+    // This prevents issues with PATH containing spaces and avoids the session closing
+    // when the agent exits or has startup issues
     execFile('tmux', [
       'new-session',
       '-d',
       '-s', tmuxSession,
       '-c', cwd,
-      `PATH=${EXEC_PATH} ${agentCmd}`
-    ], EXEC_OPTIONS, (error) => {
-      if (error) {
-        log(`Failed to spawn session: ${error.message}`)
-        reject(new Error(`Failed to spawn session: ${error.message}`))
+    ], EXEC_OPTIONS, (createError) => {
+      if (createError) {
+        log(`Failed to create tmux session: ${createError.message}`)
+        reject(new Error(`Failed to create tmux session: ${createError.message}`))
         return
       }
 
-      const session: ManagedSession = {
-        id,
-        name,
-        type: 'internal',
-        agent,
-        tmuxSession,
-        status: 'idle',
-        createdAt: Date.now(),
-        lastActivity: Date.now(),
-        cwd,
-      }
+      // Now send the agent command to the session
+      execFile('tmux', [
+        'send-keys',
+        '-t', tmuxSession,
+        agentCmd,
+        'Enter'
+      ], EXEC_OPTIONS, (sendError) => {
+        if (sendError) {
+          log(`Failed to send command to session: ${sendError.message}`)
+          // Kill the empty session since we couldn't start the agent
+          exec(`tmux kill-session -t ${tmuxSession}`, EXEC_OPTIONS)
+          reject(new Error(`Failed to start ${agent}: ${sendError.message}`))
+          return
+        }
 
-      managedSessions.set(id, session)
-      log(`Created ${agent} session: ${name} (${id.slice(0, 8)}) -> tmux:${tmuxSession} cmd:'${agentCmd}'`)
+        const session: ManagedSession = {
+          id,
+          name,
+          type: 'internal',
+          agent,
+          tmuxSession,
+          status: 'idle',
+          createdAt: Date.now(),
+          lastActivity: Date.now(),
+          cwd,
+        }
 
-      // Track git status for this session
-      if (cwd) {
-        gitStatusManager.track(id, cwd)
-        // Remember this directory for future autocomplete
-        projectsManager.addProject(cwd, name)
-      }
+        managedSessions.set(id, session)
+        log(`Created ${agent} session: ${name} (${id.slice(0, 8)}) -> tmux:${tmuxSession} cmd:'${agentCmd}'`)
 
-      // Broadcast and persist
-      broadcastSessions()
-      saveSessions()
+        // Track git status for this session
+        if (cwd) {
+          gitStatusManager.track(id, cwd)
+          // Remember this directory for future autocomplete
+          projectsManager.addProject(cwd, name)
+        }
 
-      resolve(session)
+        // Broadcast and persist
+        broadcastSessions()
+        saveSessions()
+
+        resolve(session)
+      })
     })
   })
 }
@@ -922,20 +949,8 @@ function deleteSession(id: string): Promise<boolean> {
       return
     }
 
-    // Kill the tmux session using execFile to prevent shell injection
-    try {
-      validateTmuxSession(session.tmuxSession)
-    } catch {
-      log(`Invalid tmux session name: ${session.tmuxSession}`)
-      resolve(false)
-      return
-    }
-
-    execFile('tmux', ['kill-session', '-t', session.tmuxSession], EXEC_OPTIONS, (error) => {
-      if (error) {
-        log(`Warning: Failed to kill tmux session: ${error.message}`)
-      }
-
+    // Helper to clean up session state
+    const cleanup = () => {
       managedSessions.delete(id)
       gitStatusManager.untrack(id)
       // Clean up mapping
@@ -949,6 +964,28 @@ function deleteSession(id: string): Promise<boolean> {
       broadcastSessions()
       saveSessions()
       resolve(true)
+    }
+
+    // External sessions don't have tmux sessions to kill
+    if (!session.tmuxSession) {
+      cleanup()
+      return
+    }
+
+    // Kill the tmux session using execFile to prevent shell injection
+    try {
+      validateTmuxSession(session.tmuxSession)
+    } catch {
+      log(`Invalid tmux session name: ${session.tmuxSession}`)
+      cleanup() // Still clean up the session record
+      return
+    }
+
+    execFile('tmux', ['kill-session', '-t', session.tmuxSession], EXEC_OPTIONS, (error: Error | null) => {
+      if (error) {
+        log(`Warning: Failed to kill tmux session: ${error.message}`)
+      }
+      cleanup()
     })
   })
 }
@@ -960,6 +997,11 @@ async function sendPromptToSession(id: string, prompt: string): Promise<{ ok: bo
   const session = managedSessions.get(id)
   if (!session) {
     return { ok: false, error: 'Session not found' }
+  }
+
+  // External sessions don't have tmux sessions
+  if (!session.tmuxSession) {
+    return { ok: false, error: 'Cannot send prompt to external session' }
   }
 
   try {
@@ -993,6 +1035,9 @@ function checkSessionHealth(): void {
     let changed = false
 
     for (const session of managedSessions.values()) {
+      // Skip external sessions (no tmux session to check)
+      if (!session.tmuxSession) continue
+
       const isAlive = activeSessions.has(session.tmuxSession)
       const newStatus = isAlive ? (session.status === 'offline' ? 'idle' : session.status) : 'offline'
 
@@ -1911,6 +1956,13 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         return
       }
 
+      // External sessions don't have tmux sessions
+      if (!session.tmuxSession) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Cannot cancel external sessions' }))
+        return
+      }
+
       try {
         validateTmuxSession(session.tmuxSession)
       } catch {
@@ -1919,7 +1971,7 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         return
       }
 
-      execFile('tmux', ['send-keys', '-t', session.tmuxSession, 'C-c'], EXEC_OPTIONS, (error) => {
+      execFile('tmux', ['send-keys', '-t', session.tmuxSession, 'C-c'], EXEC_OPTIONS, (error: Error | null) => {
         res.writeHead(200, { 'Content-Type': 'application/json' })
         if (error) {
           res.end(JSON.stringify({ ok: false, error: error.message }))
@@ -1972,6 +2024,13 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         return
       }
 
+      // External sessions can't be restarted (no tmux session)
+      if (!session.tmuxSession) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Cannot restart external sessions' }))
+        return
+      }
+
       // Validate inputs to prevent command injection
       try {
         validateTmuxSession(session.tmuxSession)
@@ -1990,41 +2049,68 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         return
       }
 
+      // Build agent command based on agent type
+      const agent = session.agent || 'claude'
+      let agentCmd: string
+      if (agent === 'codex') {
+        agentCmd = `codex -C ${cwd}`
+      } else {
+        agentCmd = 'claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions'
+      }
+
+      // TypeScript now knows tmuxSession is string (not undefined)
+      const tmuxSessionName = session.tmuxSession
+
       // Kill existing tmux session if it exists (ignore errors)
-      execFile('tmux', ['kill-session', '-t', session.tmuxSession], EXEC_OPTIONS, () => {
-        // Respawn tmux session with claude using execFile
+      execFile('tmux', ['kill-session', '-t', tmuxSessionName], EXEC_OPTIONS, () => {
+        // Two-step approach: create session, then send command
         execFile('tmux', [
           'new-session',
           '-d',
-          '-s', session.tmuxSession,
+          '-s', tmuxSessionName,
           '-c', cwd,
-          `PATH=${EXEC_PATH} claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions`
-        ], EXEC_OPTIONS, (error) => {
-          if (error) {
+        ], EXEC_OPTIONS, (createError: Error | null) => {
+          if (createError) {
             res.writeHead(500, { 'Content-Type': 'application/json' })
-            res.end(JSON.stringify({ ok: false, error: `Failed to restart: ${error.message}` }))
+            res.end(JSON.stringify({ ok: false, error: `Failed to create tmux session: ${createError.message}` }))
             return
           }
 
-          // Update session state
-          session.status = 'idle'
-          session.lastActivity = Date.now()
-          session.claudeSessionId = undefined // Will be re-linked when events come in
-          session.currentTool = undefined
-
-          // Clear old linking
-          for (const [claudeId, managedId] of claudeToManagedMap) {
-            if (managedId === session.id) {
-              claudeToManagedMap.delete(claudeId)
+          // Send the agent command
+          execFile('tmux', [
+            'send-keys',
+            '-t', tmuxSessionName,
+            agentCmd,
+            'Enter'
+          ], EXEC_OPTIONS, (sendError: Error | null) => {
+            if (sendError) {
+              exec(`tmux kill-session -t ${tmuxSessionName}`, EXEC_OPTIONS)
+              res.writeHead(500, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ ok: false, error: `Failed to restart: ${sendError.message}` }))
+              return
             }
-          }
 
-          log(`Restarted session: ${session.name} (${session.id.slice(0, 8)})`)
-          broadcastSessions()
-          saveSessions()
+            // Update session state
+            session.status = 'idle'
+            session.lastActivity = Date.now()
+            session.claudeSessionId = undefined // Will be re-linked when events come in
+            session.codexThreadId = undefined // Clear Codex thread ID too
+            session.currentTool = undefined
 
-          res.writeHead(200, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ ok: true, session }))
+            // Clear old linking
+            for (const [claudeId, managedId] of claudeToManagedMap) {
+              if (managedId === session.id) {
+                claudeToManagedMap.delete(claudeId)
+              }
+            }
+
+            log(`Restarted ${agent} session: ${session.name} (${session.id.slice(0, 8)})`)
+            broadcastSessions()
+            saveSessions()
+
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ ok: true, session }))
+          })
         })
       })
       return

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,8 @@ import type {
   TextTile,
   CreateTextTileRequest,
   UpdateTextTileRequest,
+  AgentType,
+  SessionFlags,
 } from '../shared/types.js'
 import { DEFAULTS } from '../shared/defaults.js'
 import { GitStatusManager } from './GitStatusManager.js'
@@ -759,13 +761,14 @@ function shortId(): string {
 }
 
 /**
- * Create a new managed session
+ * Create a new managed session (Claude or Codex)
  */
 function createSession(options: CreateSessionRequest = {}): Promise<ManagedSession> {
   return new Promise((resolve, reject) => {
     const id = randomUUID()
     sessionCounter++
-    const name = options.name || `Claude ${sessionCounter}`
+    const agent = options.agent || 'claude'
+    const name = options.name || `${agent === 'codex' ? 'Codex' : 'Claude'} ${sessionCounter}`
     const tmuxSession = `vibecraft-${shortId()}`
 
     // Validate cwd to prevent command injection
@@ -777,34 +780,62 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       return
     }
 
-    // Build claude command with flags
     const flags = options.flags || {}
-    const claudeArgs: string[] = []
+    let agentCmd: string
 
-    // Defaults: continue=true, skipPermissions=true, chrome=false
-    if (flags.continue !== false) {
-      claudeArgs.push('-c')
-    }
-    if (flags.skipPermissions !== false) {
-      // --permission-mode=bypassPermissions skips the workspace trust dialog
-      // --dangerously-skip-permissions skips tool permission prompts
-      claudeArgs.push('--permission-mode=bypassPermissions')
-      claudeArgs.push('--dangerously-skip-permissions')
-    }
-    if (flags.chrome) {
-      claudeArgs.push('--chrome')
+    if (agent === 'codex') {
+      // Build codex command with flags
+      const codexArgs: string[] = ['-C', cwd]
+
+      // Add model if specified
+      if (flags.model) {
+        codexArgs.push(`--model=${flags.model}`)
+      }
+
+      // Handle permission flags
+      if (flags.skipPermissions === true) {
+        codexArgs.push('--dangerously-bypass-approvals-and-sandbox')
+      } else if (flags.fullAuto === true || (flags.sandbox === 'workspace-write' && flags.approval === 'on-request')) {
+        codexArgs.push('--full-auto')
+      } else {
+        if (flags.sandbox) {
+          codexArgs.push(`--sandbox=${flags.sandbox}`)
+        }
+        if (flags.approval) {
+          codexArgs.push(`--ask-for-approval=${flags.approval}`)
+        }
+      }
+
+      agentCmd = `codex ${codexArgs.join(' ')}`
+    } else {
+      // Build claude command with flags
+      const claudeArgs: string[] = []
+
+      // Defaults: continue=true, skipPermissions=true, chrome=false
+      if (flags.continue !== false) {
+        claudeArgs.push('-c')
+      }
+      if (flags.skipPermissions !== false) {
+        // --permission-mode=bypassPermissions skips the workspace trust dialog
+        // --dangerously-skip-permissions skips tool permission prompts
+        claudeArgs.push('--permission-mode=bypassPermissions')
+        claudeArgs.push('--dangerously-skip-permissions')
+      }
+      if (flags.chrome) {
+        claudeArgs.push('--chrome')
+      }
+
+      agentCmd = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude'
     }
 
-    const claudeCmd = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude'
-
-    // Spawn tmux session with claude using execFile to prevent shell injection
+    // Spawn tmux session with agent using execFile to prevent shell injection
     // Arguments are passed as array, not interpolated into a shell string
     execFile('tmux', [
       'new-session',
       '-d',
       '-s', tmuxSession,
       '-c', cwd,
-      `PATH=${EXEC_PATH} ${claudeCmd}`
+      `PATH=${EXEC_PATH} ${agentCmd}`
     ], EXEC_OPTIONS, (error) => {
       if (error) {
         log(`Failed to spawn session: ${error.message}`)
@@ -815,6 +846,8 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       const session: ManagedSession = {
         id,
         name,
+        type: 'internal',
+        agent,
         tmuxSession,
         status: 'idle',
         createdAt: Date.now(),
@@ -823,7 +856,7 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       }
 
       managedSessions.set(id, session)
-      log(`Created session: ${name} (${id.slice(0, 8)}) -> tmux:${tmuxSession} cmd:'${claudeCmd}'`)
+      log(`Created ${agent} session: ${name} (${id.slice(0, 8)}) -> tmux:${tmuxSession} cmd:'${agentCmd}'`)
 
       // Track git status for this session
       if (cwd) {
@@ -1038,6 +1071,13 @@ function loadSessions(): void {
         // Mark all as offline initially - health check will update
         session.status = 'offline'
         session.currentTool = undefined
+        // Backwards compatibility: add type and agent if missing
+        if (!session.type) {
+          session.type = session.tmuxSession ? 'internal' : 'external'
+        }
+        if (!session.agent) {
+          session.agent = 'claude'  // Default to Claude for legacy sessions
+        }
         managedSessions.set(session.id, session)
         // Track git status if session has a cwd
         if (session.cwd) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -260,21 +260,41 @@ export interface TaskToolInput {
 // Session Management (Orchestration)
 // ============================================================================
 
-/** Status of a managed Claude session */
+/** Status of a managed session */
 export type SessionStatus = 'idle' | 'working' | 'waiting' | 'offline'
 
-/** A managed Claude session */
+/** Session type - how it was created */
+export type SessionType = 'internal' | 'external'
+
+/** Agent type - which AI agent is running */
+export type AgentType = 'claude' | 'codex'
+
+/** Terminal info for external sessions (enables message sending) */
+export interface TerminalInfo {
+  app: string           // e.g., 'iTerm2', 'Terminal', 'Warp'
+  windowId?: string     // For AppleScript targeting
+  tabId?: string
+  paneId?: string       // For tmux within terminal
+}
+
+/** A managed Claude/Codex session */
 export interface ManagedSession {
   /** Our internal ID (UUID) */
   id: string
   /** User-friendly name ("Frontend", "Tests") */
   name: string
-  /** Actual tmux session name */
-  tmuxSession: string
+  /** Session type: 'internal' = created via New Zone (tmux), 'external' = detected from hooks */
+  type: SessionType
+  /** Agent type: 'claude' or 'codex' - which AI agent is running */
+  agent: AgentType
+  /** Actual tmux session name (only for internal sessions) */
+  tmuxSession?: string
   /** Current status */
   status: SessionStatus
   /** Claude Code session ID (from events, may differ from our ID) */
   claudeSessionId?: string
+  /** Codex thread ID (for Codex agent) */
+  codexThreadId?: string
   /** Creation timestamp */
   createdAt: number
   /** Last activity timestamp */
@@ -295,6 +315,12 @@ export interface ManagedSession {
     q: number
     r: number
   }
+  /** Agent's suggested next prompt (shown in gray at input line) */
+  suggestion?: string
+  /** Ralph Wiggum mode - auto-accept suggestions */
+  autoAccept?: boolean
+  /** Terminal info for external sessions (enables message sending) */
+  terminal?: TerminalInfo
 }
 
 /** Git repository status */
@@ -347,16 +373,31 @@ export interface KnownProject {
   useCount: number
 }
 
+/** Session creation flags */
+export interface SessionFlags {
+  // Claude-specific flags
+  continue?: boolean           // Claude: -c (continue conversation)
+  skipPermissions?: boolean    // Claude: --dangerously-skip-permissions, Codex: --dangerously-bypass-approvals-and-sandbox
+  chrome?: boolean             // Claude: --chrome
+
+  // Codex-specific flags
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access'  // Codex: --sandbox
+  approval?: 'untrusted' | 'on-failure' | 'on-request' | 'never'    // Codex: --ask-for-approval
+  fullAuto?: boolean           // Codex: --full-auto (convenience alias)
+  model?: string               // Codex: --model (e.g., 'gpt-5.2-codex', 'o3')
+
+  // General flags
+  openTerminal?: boolean       // Open terminal window for this session
+}
+
 /** Request to create a new session */
 export interface CreateSessionRequest {
   name?: string
   cwd?: string
-  /** Claude command flags */
-  flags?: {
-    continue?: boolean        // -c (continue last conversation)
-    skipPermissions?: boolean  // --dangerously-skip-permissions
-    chrome?: boolean        // --chrome
-  }
+  /** Agent type: 'claude' (default) or 'codex' */
+  agent?: AgentType
+  /** Session flags for Claude or Codex CLI */
+  flags?: SessionFlags
 }
 
 /** Request to update a session */

--- a/src/api/SessionAPI.ts
+++ b/src/api/SessionAPI.ts
@@ -5,13 +5,7 @@
  * UI logic and state updates are handled by the caller (main.ts).
  */
 
-import type { ManagedSession } from '../../shared/types'
-
-export interface SessionFlags {
-  continue?: boolean
-  skipPermissions?: boolean
-  chrome?: boolean
-}
+import type { ManagedSession, SessionFlags, AgentType } from '../../shared/types'
 
 export interface CreateSessionResponse {
   ok: boolean
@@ -36,18 +30,19 @@ export interface ServerInfoResponse {
 export function createSessionAPI(apiUrl: string) {
   return {
     /**
-     * Create a new managed session
+     * Create a new managed session (Claude or Codex)
      */
     async createSession(
       name?: string,
       cwd?: string,
-      flags?: SessionFlags
+      flags?: SessionFlags,
+      agent?: AgentType
     ): Promise<CreateSessionResponse> {
       try {
         const response = await fetch(`${apiUrl}/sessions`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, cwd, flags }),
+          body: JSON.stringify({ name, cwd, flags, agent }),
         })
         return await response.json()
       } catch (e) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,4 +2,5 @@
  * API modules for server communication
  */
 
-export { createSessionAPI, type SessionAPI, type SessionFlags } from './SessionAPI'
+export { createSessionAPI, type SessionAPI } from './SessionAPI'
+export type { SessionFlags, AgentType } from '../../shared/types'

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,8 @@ import {
   type PreToolUseEvent,
   type PostToolUseEvent,
   type ManagedSession,
+  type SessionFlags,
+  type AgentType,
 } from '../shared/types'
 import { soundManager } from './audio'
 
@@ -363,22 +365,17 @@ function selectManagedSession(sessionId: string | null): void {
 }
 
 /**
- * Create a new managed session
+ * Create a new managed session (Claude or Codex)
  */
-interface SessionFlags {
-  continue?: boolean
-  skipPermissions?: boolean
-  chrome?: boolean
-}
-
 async function createManagedSession(
   name?: string,
   cwd?: string,
   flags?: SessionFlags,
   hintPosition?: { x: number; z: number },
-  pendingZoneId?: string
+  pendingZoneId?: string,
+  agent?: AgentType
 ): Promise<void> {
-  const data = await sessionAPI.createSession(name, cwd, flags)
+  const data = await sessionAPI.createSession(name, cwd, flags, agent)
 
   if (!data.ok) {
     console.error('Failed to create session:', data.error)
@@ -626,19 +623,54 @@ function setupManagedSessions(): void {
     currentModalHint = null  // Clear hint when modal closes
   }
 
+  // Agent selector toggle logic
+  const agentRadios = document.querySelectorAll('input[name="session-agent"]')
+  const claudeOptionsEl = document.getElementById('claude-options')
+  const codexOptionsEl = document.getElementById('codex-options')
+
+  agentRadios.forEach(radio => {
+    radio.addEventListener('change', (e) => {
+      const target = e.target as HTMLInputElement
+      if (target.value === 'codex') {
+        claudeOptionsEl?.style.setProperty('display', 'none')
+        codexOptionsEl?.style.setProperty('display', 'block')
+      } else {
+        claudeOptionsEl?.style.setProperty('display', 'block')
+        codexOptionsEl?.style.setProperty('display', 'none')
+      }
+    })
+  })
+
   const handleCreate = (): void => {
     const name = nameInput?.value.trim() || undefined
     const cwd = cwdInput?.value.trim() || undefined
 
-    // Read flag checkboxes
-    const continueCheck = document.getElementById('session-opt-continue') as HTMLInputElement
-    const skipPermsCheck = document.getElementById('session-opt-skip-perms') as HTMLInputElement
-    const chromeCheck = document.getElementById('session-opt-chrome') as HTMLInputElement
+    // Get selected agent
+    const agentRadio = document.querySelector('input[name="session-agent"]:checked') as HTMLInputElement
+    const agent: AgentType = (agentRadio?.value as AgentType) || 'claude'
 
-    const flags: SessionFlags = {
-      continue: continueCheck?.checked ?? true,
-      skipPermissions: skipPermsCheck?.checked ?? true,
-      chrome: chromeCheck?.checked ?? false,
+    let flags: SessionFlags
+
+    if (agent === 'codex') {
+      // Read Codex-specific flags
+      const codexSkipPermsCheck = document.getElementById('session-opt-codex-skip-perms') as HTMLInputElement
+      const codexModelSelect = document.getElementById('session-codex-model') as HTMLSelectElement
+
+      flags = {
+        skipPermissions: codexSkipPermsCheck?.checked ?? true,
+        model: codexModelSelect?.value || undefined,
+      }
+    } else {
+      // Read Claude-specific flags
+      const continueCheck = document.getElementById('session-opt-continue') as HTMLInputElement
+      const skipPermsCheck = document.getElementById('session-opt-skip-perms') as HTMLInputElement
+      const chromeCheck = document.getElementById('session-opt-chrome') as HTMLInputElement
+
+      flags = {
+        continue: continueCheck?.checked ?? true,
+        skipPermissions: skipPermsCheck?.checked ?? true,
+        chrome: chromeCheck?.checked ?? false,
+      }
     }
 
     // Capture hint before closing modal (closeModal clears it)
@@ -667,7 +699,7 @@ function setupManagedSessions(): void {
     soundManager.play('modal_confirm')
 
     closeModal()
-    createManagedSession(name, cwd, flags, hintPosition ?? undefined, pendingId)
+    createManagedSession(name, cwd, flags, hintPosition ?? undefined, pendingId, agent)
   }
 
   const handleCancel = (): void => {
@@ -1772,8 +1804,11 @@ function handleEvent(event: ClaudeEvent) {
 
   // If no session (unlinked), still add to feed/timeline with default color but skip 3D updates
   const eventColor = session?.color ?? 0x888888
+  // Look up managed session to get agent type
+  const managedSession = state.managedSessions.find(s => s.id === event.sessionId || s.claudeSessionId === event.sessionId)
+  const agentType = managedSession?.agent
   state.timelineManager?.add(event, eventColor)
-  state.feedManager?.add(event, eventColor)
+  state.feedManager?.add(event, eventColor, agentType)
 
   // Skip 3D scene updates for unlinked sessions
   if (!session) {
@@ -1871,7 +1906,7 @@ function handleEvent(event: ClaudeEvent) {
 
       // Show thinking indicator AFTER feedManager.add() to ensure correct order
       // (prompt appears first, then thinking indicator)
-      state.feedManager?.showThinking(event.sessionId, session.color)
+      state.feedManager?.showThinking(event.sessionId, session.color, managedSession?.agent)
 
       // Update UI badge (zone attention cleared by zoneHandlers)
       updateAttentionBadge()

--- a/src/styles/modals.css
+++ b/src/styles/modals.css
@@ -238,6 +238,89 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
+/* Agent Selector */
+.modal-agent-selector {
+  display: flex;
+  gap: 12px;
+}
+
+.modal-agent-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.modal-agent-option:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.modal-agent-option:has(input:checked) {
+  background: rgba(100, 200, 255, 0.15);
+  border-color: rgba(100, 200, 255, 0.4);
+}
+
+.modal-agent-option input[type="radio"] {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+}
+
+.modal-agent-option input[type="radio"]:checked {
+  border-color: #64c8ff;
+  background: #64c8ff;
+}
+
+.modal-agent-option input[type="radio"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 6px;
+  height: 6px;
+  background: #1a1a2e;
+  border-radius: 50%;
+}
+
+.modal-agent-option .agent-label {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* Model Select */
+.modal-field select {
+  width: 100%;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.modal-field select:focus {
+  outline: none;
+  border-color: rgba(100, 200, 255, 0.5);
+}
+
+.modal-field select option {
+  background: #1a1a2e;
+  color: rgba(255, 255, 255, 0.9);
+}
+
 /* New Session Modal */
 #new-session-modal {
   position: fixed;

--- a/src/ui/FeedManager.ts
+++ b/src/ui/FeedManager.ts
@@ -9,7 +9,7 @@
  */
 
 import { getToolIcon } from '../utils/ToolUtils'
-import type { ClaudeEvent, PreToolUseEvent, PostToolUseEvent } from '../../shared/types'
+import type { ClaudeEvent, PreToolUseEvent, PostToolUseEvent, AgentType } from '../../shared/types'
 
 export class FeedManager {
   private feedEl: HTMLElement | null = null
@@ -122,7 +122,7 @@ export class FeedManager {
   /**
    * Show a "thinking" indicator for a session
    */
-  showThinking(sessionId: string, sessionColor?: number): void {
+  showThinking(sessionId: string, sessionColor?: number, agent?: AgentType): void {
     if (!this.feedEl) return
 
     // Don't show duplicate thinking indicators
@@ -141,10 +141,11 @@ export class FeedManager {
       item.style.borderLeftStyle = 'solid'
     }
 
+    const agentName = agent === 'codex' ? 'Codex' : 'Claude'
     item.innerHTML = `
       <div class="feed-item-header">
         <div class="feed-item-icon thinking-icon">🤔</div>
-        <div class="feed-item-title">Claude is thinking</div>
+        <div class="feed-item-title">${agentName} is thinking</div>
         <div class="thinking-dots"><span>.</span><span>.</span><span>.</span></div>
       </div>
     `
@@ -192,7 +193,7 @@ export class FeedManager {
   /**
    * Add an event to the feed
    */
-  add(event: ClaudeEvent, sessionColor?: number): void {
+  add(event: ClaudeEvent, sessionColor?: number, agent?: AgentType): void {
     if (!this.feedEl) return
 
     // Skip duplicates
@@ -394,7 +395,8 @@ export class FeedManager {
           }
         }
 
-        // If we have a response, show it as Claude's message
+        // If we have a response, show it as the agent's message
+        const agentName = agent === 'codex' ? 'Codex' : 'Claude'
         if (response) {
           item.classList.add('assistant-response')
           const isLong = response.length > 2000
@@ -402,7 +404,7 @@ export class FeedManager {
           item.innerHTML = `
             <div class="feed-item-header">
               <div class="feed-item-icon">🤖</div>
-              <div class="feed-item-title">Claude</div>
+              <div class="feed-item-title">${agentName}</div>
               <div class="feed-item-time">${new Date(event.timestamp).toLocaleTimeString()}</div>
             </div>
             <div class="feed-item-content assistant-text">${renderMarkdown(displayResponse)}${isLong ? '<span class="show-more">... [show more - Alt+E]</span>' : ''}</div>

--- a/src/ui/ZoneInfoModal.ts
+++ b/src/ui/ZoneInfoModal.ts
@@ -119,7 +119,7 @@ function renderContent(data: ZoneInfoData): void {
       </div>
       <div class="zone-info-row">
         <span class="zone-info-label">tmux Session</span>
-        <span class="zone-info-value zone-info-mono">${escapeHtml(s.tmuxSession)}</span>
+        <span class="zone-info-value zone-info-mono">${escapeHtml(s.tmuxSession || '(external)')}</span>
       </div>
       <div class="zone-info-row">
         <span class="zone-info-label">Created</span>


### PR DESCRIPTION
## Summary

This PR adds support for OpenAI Codex CLI alongside Claude Code, enabling multi-agent workflows:

- **Agent type selection**: Users can choose between Claude and Codex when creating sessions
- **Session management**: Internal sessions now properly track agent type
- **Activity feed**: Shows correct agent name (Claude vs Codex) in responses
- **Bug fixes**: Fixed tmux session creation for paths containing spaces

## Changes

### Types (`shared/types.ts`)
- Add `AgentType`: `'claude' | 'codex'`
- Add `SessionType`: `'internal' | 'external'`
- Add Codex-specific fields to `SessionFlags`
- Extend `ManagedSession` with agent tracking

### Server (`server/index.ts`)
- Session creation handles both Claude and Codex commands
- Restart endpoint supports both agent types
- Fixed: Use two-step tmux creation (create session → send-keys) to avoid PATH space issues
- Fixed: All TypeScript errors related to optional `tmuxSession` field

### Frontend
- Agent selector in New Zone modal
- Shows/hides relevant options per agent type
- Activity feed displays correct agent name

## Testing

- Created Claude session: ✅ Session runs correctly
- Created Codex session: ✅ Session runs correctly
- Build passes: ✅ No TypeScript errors
- Both agents can receive prompts and respond

## Screenshots

The UI adds a simple radio selector for Claude vs Codex, with agent-specific options shown below.

---
🤖 Generated with [Claude Code](https://claude.ai/code)