### PR TITLE
feat: Surface context window usage per session

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -327,6 +327,9 @@ function loadDeepgramKey(): string | null {
 /** Map Claude Code session IDs to our managed session IDs */
 const claudeToManagedMap = new Map<string, string>()
 
+/** Reverse lookup: tmux session name -> managed session ID (avoids linear search in pollTokens) */
+const tmuxToManagedMap = new Map<string, string>()
+
 /** Counter for generating session names */
 let sessionCounter = 0
 
@@ -423,14 +426,8 @@ function pollTokens(tmuxSession: string): void {
 
       debug(`Tokens updated: ${tokens} (cumulative: ${session.cumulative})`)
 
-      // Find managed session ID for this tmux session
-      let managedSessionId: string | undefined
-      for (const [id, ms] of managedSessions) {
-        if (ms.tmuxSession === tmuxSession) {
-          managedSessionId = id
-          break
-        }
-      }
+      // Find managed session ID for this tmux session (O(1) lookup via reverse map)
+      const managedSessionId = tmuxToManagedMap.get(tmuxSession)
 
       // Broadcast token update
       broadcast({
@@ -833,6 +830,7 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       }
 
       managedSessions.set(id, session)
+      tmuxToManagedMap.set(tmuxSession, id)
       log(`Created session: ${name} (${id.slice(0, 8)}) -> tmux:${tmuxSession} cmd:'${claudeCmd}'`)
 
       // Track git status for this session
@@ -913,6 +911,7 @@ function deleteSession(id: string): Promise<boolean> {
         log(`Warning: Failed to kill tmux session: ${error.message}`)
       }
 
+      tmuxToManagedMap.delete(session.tmuxSession)
       managedSessions.delete(id)
       gitStatusManager.untrack(id)
       // Clean up mapping
@@ -1049,6 +1048,10 @@ function loadSessions(): void {
         session.status = 'offline'
         session.currentTool = undefined
         managedSessions.set(session.id, session)
+        // Populate reverse lookup map
+        if (session.tmuxSession) {
+          tmuxToManagedMap.set(session.tmuxSession, session.id)
+        }
         // Track git status if session has a cwd
         if (session.cwd) {
           gitStatusManager.track(session.id, session.cwd)

--- a/server/index.ts
+++ b/server/index.ts
@@ -423,11 +423,21 @@ function pollTokens(tmuxSession: string): void {
 
       debug(`Tokens updated: ${tokens} (cumulative: ${session.cumulative})`)
 
+      // Find managed session ID for this tmux session
+      let managedSessionId: string | undefined
+      for (const [id, ms] of managedSessions) {
+        if (ms.tmuxSession === tmuxSession) {
+          managedSessionId = id
+          break
+        }
+      }
+
       // Broadcast token update
       broadcast({
         type: 'tokens',
         payload: {
           session: tmuxSession,
+          sessionId: managedSessionId,
           current: tokens,
           cumulative: session.cumulative,
         },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -160,7 +160,7 @@ export type ServerMessage =
   | { type: 'history'; payload: ClaudeEvent[] }
   | { type: 'connected'; payload: { sessionId: string } }
   | { type: 'error'; payload: { message: string } }
-  | { type: 'tokens'; payload: { session: string; current: number; cumulative: number } }
+  | { type: 'tokens'; payload: { session: string; sessionId?: string; current: number; cumulative: number } }
   | { type: 'sessions'; payload: ManagedSession[] }
   | { type: 'session_update'; payload: ManagedSession }
   | { type: 'permission_prompt'; payload: { sessionId: string; tool: string; context: string; options: PermissionOption[] } }

--- a/src/events/EventClient.ts
+++ b/src/events/EventClient.ts
@@ -7,7 +7,7 @@ import type { ClaudeEvent, ServerMessage, ClientMessage, ManagedSession } from '
 export type EventHandler = (event: ClaudeEvent) => void
 export type HistoryHandler = (events: ClaudeEvent[]) => void
 export type ConnectionHandler = (connected: boolean) => void
-export type TokensHandler = (data: { session: string; current: number; cumulative: number }) => void
+export type TokensHandler = (data: { session: string; sessionId?: string; current: number; cumulative: number }) => void
 export type SessionsHandler = (sessions: ManagedSession[]) => void
 export type SessionUpdateHandler = (session: ManagedSession) => void
 export type RawMessageHandler = (data: { type: string; payload?: unknown }) => void
@@ -263,7 +263,7 @@ export class EventClient {
     }
   }
 
-  private notifyTokensHandlers(data: { session: string; current: number; cumulative: number }): void {
+  private notifyTokensHandlers(data: { session: string; sessionId?: string; current: number; cumulative: number }): void {
     for (const handler of this.tokensHandlers) {
       try {
         handler(data)

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,6 +211,7 @@ function renderManagedSessions(): void {
   state.managedSessions.forEach((session, index) => {
     const el = document.createElement('div')
     el.className = 'session-item'
+    el.dataset.sessionId = session.id  // For targeted DOM updates (e.g., token updates)
     if (session.id === state.selectedManagedSession) {
       el.classList.add('active')
     }
@@ -2694,11 +2695,41 @@ function init() {
     }
 
     // Update managed session tokens if sessionId is provided
+    // Uses targeted DOM update instead of full re-render for performance
     if (data.sessionId) {
       const session = state.managedSessions.find(s => s.id === data.sessionId)
       if (session) {
         session.tokens = { current: data.current, cumulative: data.cumulative }
-        renderManagedSessions()
+
+        // Targeted DOM update: only update the token element for this session
+        const sessionEl = document.querySelector(`.session-item[data-session-id="${data.sessionId}"]`) as HTMLElement | null
+        if (sessionEl) {
+          let tokensEl = sessionEl.querySelector('.session-tokens')
+          if (!tokensEl) {
+            // Create token element if it doesn't exist
+            tokensEl = document.createElement('div')
+            tokensEl.className = 'session-tokens'
+            const infoEl = sessionEl.querySelector('.session-info')
+            const promptEl = sessionEl.querySelector('.session-prompt')
+            if (promptEl) {
+              infoEl?.insertBefore(tokensEl, promptEl)
+            } else {
+              infoEl?.appendChild(tokensEl)
+            }
+          }
+          tokensEl.textContent = `⚡ ${formatTokens(data.current)}`
+
+          // Update tooltip with new token info
+          const tooltipParts = sessionEl.title.split('\n')
+          const tokenLineIdx = tooltipParts.findIndex((l: string) => l.startsWith('Tokens:'))
+          const tokenLine = `Tokens: ${data.current.toLocaleString()} current, ${data.cumulative.toLocaleString()} total`
+          if (tokenLineIdx >= 0) {
+            tooltipParts[tokenLineIdx] = tokenLine
+          } else {
+            tooltipParts.push(tokenLine)
+          }
+          sessionEl.title = tooltipParts.join('\n')
+        }
       }
     }
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,6 +254,11 @@ function renderManagedSessions(): void {
       ? (lastPrompt.length > 35 ? lastPrompt.slice(0, 32) + '...' : lastPrompt)
       : null
 
+    // Token display (if available)
+    const tokenDisplay = session.tokens
+      ? `<div class="session-tokens">⚡ ${formatTokens(session.tokens.current)}</div>`
+      : ''
+
     // Build detailed tooltip
     const tooltipParts = [
       `Name: ${session.name}`,
@@ -262,6 +267,7 @@ function renderManagedSessions(): void {
       session.claudeSessionId ? `Claude ID: ${session.claudeSessionId.slice(0, 12)}...` : 'Not linked yet',
       session.cwd ? `Dir: ${session.cwd}` : '',
       session.lastActivity ? `Last active: ${new Date(session.lastActivity).toLocaleString()}` : '',
+      session.tokens ? `Tokens: ${session.tokens.current.toLocaleString()} current, ${session.tokens.cumulative.toLocaleString()} total` : '',
       lastPrompt ? `Last prompt: ${lastPrompt}` : '',
     ].filter(Boolean)
     el.title = tooltipParts.join('\n')
@@ -272,6 +278,7 @@ function renderManagedSessions(): void {
       <div class="session-info">
         <div class="session-name">${escapeHtml(session.name)}</div>
         <div class="${detailClass}">${detail}${!needsAttention && session.status !== 'offline' && lastActive ? ` · ${lastActive}` : ''}</div>
+        ${tokenDisplay}
         ${truncatedPrompt ? `<div class="session-prompt">💬 ${escapeHtml(truncatedPrompt)}</div>` : ''}
       </div>
       <div class="session-actions">
@@ -2684,6 +2691,15 @@ function init() {
     if (tokenCounter) {
       tokenCounter.textContent = `⚡ ${formatTokens(data.cumulative)}`
       tokenCounter.title = `${data.cumulative.toLocaleString()} tokens used`
+    }
+
+    // Update managed session tokens if sessionId is provided
+    if (data.sessionId) {
+      const session = state.managedSessions.find(s => s.id === data.sessionId)
+      if (session) {
+        session.tokens = { current: data.current, cumulative: data.cumulative }
+        renderManagedSessions()
+      }
     }
   })
 

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -273,3 +273,12 @@
   border-color: rgba(167, 139, 250, 0.4);
   color: #c4b5fd;
 }
+
+/* Token display */
+.session-tokens {
+  font-size: 10px;
+  color: #22d3ee;
+  font-family: var(--font-mono, monospace);
+  margin-top: 1px;
+  opacity: 0.8;
+}


### PR DESCRIPTION
## Summary
- Server now includes managed session ID when broadcasting token updates
- Client maps tokens to individual `ManagedSession.tokens` field  
- Sidebar displays token count (⚡ Xk tok) for each session
- Tooltip shows detailed token info (current + cumulative)
- Zone Info modal already reads from `session.tokens`, now works

## Test plan
- [ ] Start Vibecraft with multiple sessions
- [ ] Send prompts to each session
- [ ] Verify tokens appear in sidebar for each session
- [ ] Hover session to see token details in tooltip
- [ ] Right-click zone → Zone Info should show token usage
- [ ] Tokens should update in real-time as sessions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)