### PR TITLE
Fix tmux session creation failing due to PATH handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -799,12 +799,14 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
 
     // Spawn tmux session with claude using execFile to prevent shell injection
     // Arguments are passed as array, not interpolated into a shell string
+    // NOTE: Must wrap in bash -c to ensure PATH is properly exported.
+    // Without this, tmux uses /bin/sh which doesn't handle PATH=... cmd syntax correctly.
     execFile('tmux', [
       'new-session',
       '-d',
       '-s', tmuxSession,
       '-c', cwd,
-      `PATH=${EXEC_PATH} ${claudeCmd}`
+      `bash -c 'export PATH="${EXEC_PATH}"; ${claudeCmd}'`
     ], EXEC_OPTIONS, (error) => {
       if (error) {
         log(`Failed to spawn session: ${error.message}`)
@@ -1953,12 +1955,13 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       // Kill existing tmux session if it exists (ignore errors)
       execFile('tmux', ['kill-session', '-t', session.tmuxSession], EXEC_OPTIONS, () => {
         // Respawn tmux session with claude using execFile
+        // NOTE: Must wrap in bash -c to ensure PATH is properly exported.
         execFile('tmux', [
           'new-session',
           '-d',
           '-s', session.tmuxSession,
           '-c', cwd,
-          `PATH=${EXEC_PATH} claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions`
+          `bash -c 'export PATH="${EXEC_PATH}"; claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions'`
         ], EXEC_OPTIONS, (error) => {
           if (error) {
             res.writeHead(500, { 'Content-Type': 'application/json' })


### PR DESCRIPTION
## Summary

- Fixes session creation failing with "Zone Not Responding" error
- Wraps tmux command in `bash -c` to ensure proper PATH handling

## Problem

When creating tmux sessions, the command `PATH=... claude` was passed directly to tmux. Without a bash wrapper, tmux uses `/bin/sh` which doesn't properly handle the `PATH=... cmd` shell syntax, causing Claude to fail to start and sessions to immediately exit.

## Solution

Wrap the command in `bash -c 'export PATH="..."; cmd'` to ensure proper PATH handling. Applied to both:
1. `createSession()` - new session creation
2. Session restart endpoint

## Testing

- Forked repo, applied fix, built from source
- Created session via API - tmux session now persists
- Verified Claude starts and runs correctly with bypass permissions

## Related

Fixes #8

## Test plan

- [ ] Create a new zone via the web UI
- [ ] Verify tmux session is created and persists
- [ ] Verify Claude is running in the session
- [ ] Test session restart functionality