### PR TITLE
fix: add Vite proxy routes and improve tmux prompt sending

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -226,24 +226,28 @@ async function sendToTmuxSafe(tmuxSession: string, text: string): Promise<void> 
   // Validate session name
   validateTmuxSession(tmuxSession)
 
-  // Create temp file with cryptographically secure random name
-  const tempFile = `/tmp/vibecraft-prompt-${Date.now()}-${randomBytes(16).toString('hex')}.txt`
-  writeFileSync(tempFile, text)
-
-  try {
-    // Load text into tmux buffer
-    await execFileAsync('tmux', ['load-buffer', tempFile])
-    // Paste buffer into session
-    await execFileAsync('tmux', ['paste-buffer', '-t', tmuxSession])
-    // Send Enter to submit
-    await new Promise(r => setTimeout(r, 100)) // Small delay like original
+  // Use send-keys -l (literal) for short prompts, paste-buffer for long ones
+  if (text.length < 500 && !text.includes('\n')) {
+    // Simple approach: send-keys -l followed by Enter
+    await execFileAsync('tmux', ['send-keys', '-t', tmuxSession, '-l', text])
+    await new Promise(r => setTimeout(r, 150))
     await execFileAsync('tmux', ['send-keys', '-t', tmuxSession, 'Enter'])
-  } finally {
-    // Clean up temp file
+  } else {
+    // For long/multiline text, use paste-buffer
+    const tempFile = `/tmp/vibecraft-prompt-${Date.now()}-${randomBytes(16).toString('hex')}.txt`
+    writeFileSync(tempFile, text)
+
     try {
-      unlinkSync(tempFile)
-    } catch {
-      // Ignore cleanup errors
+      await execFileAsync('tmux', ['load-buffer', tempFile])
+      await execFileAsync('tmux', ['paste-buffer', '-t', tmuxSession])
+      await new Promise(r => setTimeout(r, 300))
+      await execFileAsync('tmux', ['send-keys', '-t', tmuxSession, 'Enter'])
+    } finally {
+      try {
+        unlinkSync(tempFile)
+      } catch {
+        // Ignore cleanup errors
+      }
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,27 @@ export default defineConfig({
         target: `ws://localhost:${serverPort}`,
         ws: true,
       },
+      '/health': {
+        target: `http://localhost:${serverPort}`,
+      },
+      '/sessions': {
+        target: `http://localhost:${serverPort}`,
+      },
+      '/prompt': {
+        target: `http://localhost:${serverPort}`,
+      },
+      '/event': {
+        target: `http://localhost:${serverPort}`,
+      },
+      '/stats': {
+        target: `http://localhost:${serverPort}`,
+      },
+      '/cancel': {
+        target: `http://localhost:${serverPort}`,
+      },
+      '/token': {
+        target: `http://localhost:${serverPort}`,
+      },
       '/api': {
         target: `http://localhost:${serverPort}`,
         rewrite: (path) => path.replace(/^\/api/, ''),


### PR DESCRIPTION
## Summary

- **Fix voice/mic in dev mode**: Add Vite proxy routes for `/health`, `/sessions`, `/prompt`, `/event`, `/stats`, `/cancel`, `/token`. The `/health` endpoint wasn't being proxied, causing the client to receive HTML instead of JSON when checking `voiceEnabled`.

- **Improve prompt sending reliability**: Use `send-keys -l` (literal) for short prompts instead of `paste-buffer`, which is more reliable. Falls back to `paste-buffer` for long/multiline text (>500 chars or contains newlines).

## Test plan

- [x] Run `pnpm dev` and verify voice input works (mic icon enabled)
- [x] Send prompts from UI to managed sessions
- [x] Verify short prompts execute immediately
- [x] Verify long prompts still work via paste-buffer