### PR TITLE
Fix missing '+ New' button and tmux session creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
                 <div class="session-name">All Sessions</div>
                 <div class="session-detail" id="all-sessions-count">No active sessions</div>
               </div>
+              <button id="new-session-btn">+ New</button>
             </div>
             <div id="managed-sessions"></div>
           </div>

--- a/server/index.ts
+++ b/server/index.ts
@@ -804,7 +804,7 @@ function createSession(options: CreateSessionRequest = {}): Promise<ManagedSessi
       '-d',
       '-s', tmuxSession,
       '-c', cwd,
-      `PATH=${EXEC_PATH} ${claudeCmd}`
+      `bash -c 'export PATH="${EXEC_PATH}"; ${claudeCmd}'`
     ], EXEC_OPTIONS, (error) => {
       if (error) {
         log(`Failed to spawn session: ${error.message}`)
@@ -1958,7 +1958,7 @@ function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           '-d',
           '-s', session.tmuxSession,
           '-c', cwd,
-          `PATH=${EXEC_PATH} claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions`
+          `bash -c 'export PATH="${EXEC_PATH}"; claude -c --permission-mode=bypassPermissions --dangerously-skip-permissions'`
         ], EXEC_OPTIONS, (error) => {
           if (error) {
             res.writeHead(500, { 'Content-Type': 'application/json' })


### PR DESCRIPTION
## Summary

- Add missing `#new-session-btn` element to index.html (UI showed "Click '+ New' to start" but no button rendered)
- Wrap tmux commands in `bash -c` to fix PATH handling (fixes #8)

## Details

**+ New button:** The CSS and JS were already in place, but the actual `<button>` element was never added to the HTML.

**tmux fix:** Sessions failed to start because tmux uses `/bin/sh` which doesn't handle `PATH=... cmd` syntax. Wrapping in `bash -c 'export PATH="..."; cmd'` fixes this. Applied to both `createSession()` and the session restart endpoint.

## Test plan

- [x] "+ New" button now visible in sessions panel
- [x] Clicking opens new session modal
- [ ] New zones create successfully (tmux sessions persist)
- [ ] Session restart works

🤖 Generated with [Claude Code](https://claude.com/claude-code)