### PR TITLE
fix: use portable shebang for NixOS compatibility

### DIFF
--- a/hooks/vibecraft-hook.sh
+++ b/hooks/vibecraft-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Vibecraft Hook - Captures Claude Code events for 3D visualization
 #
 # This script is called by Claude Code hooks and:


### PR DESCRIPTION
## Summary
- Change `#!/bin/bash` to `#!/usr/bin/env bash` in the hook script for better portability

## Problem
On NixOS, bash is not located at `/bin/bash` but in the Nix store (e.g., `/nix/store/.../bin/bash`), causing the hook to fail with:
```
/bin/bash: bad interpreter: No such file or directory
```

## Solution
Using `#!/usr/bin/env bash` finds bash via PATH, which works on:
- NixOS
- FreeBSD (bash at `/usr/local/bin/bash`)
- macOS with Homebrew bash
- Any system where bash is installed in a non-standard location

This is the standard portable shebang approach.

## Test plan
- [x] Tested on NixOS - hooks now execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)